### PR TITLE
[W-13592199] Handling policy versioning through Cargo.toml file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright 2023 Salesforce, Inc. All rights reserved.
 [package]
 name = "{{ crate_name }}"
-version = "0.1.0"
+version = "{{ asset-version }}"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,15 @@ TARGET_DIR     := target/$(TARGET)/release
 NAME           := {{ crate_name }}
 DEFINITION_NAME := $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
 DEFINITION_GCL_PATH := $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition)
+ASSET_VERSION := $(shell cargo anypoint get-version)
 
-.phony: build-definition
-build-definition: $(DEFINITION_GCL)
-	@anypoint-cli-v4 pdk policy-project build-definition
+.phony: build-asset-files
+build-asset-files: $(DEFINITION_GCL)
+	@anypoint-cli-v4 pdk policy-project build-asset-files --version $(ASSET_VERSION)
 	@cargo anypoint config-gen -p -m $(DEFINITION_GCL_PATH) -o src/generated/config.rs
 
 .phony: build
-build: build-definition
+build: build-asset-files
 	@cargo build --target $(TARGET) --release
 	@cp $(DEFINITION_GCL_PATH) $(TARGET_DIR)/$(NAME)_definition.yaml
 	@cargo anypoint gcl-gen -d $(DEFINITION_NAME) -w $(TARGET_DIR)/$(NAME).wasm -o $(TARGET_DIR)/$(NAME)_implementation.yaml

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,10 @@
 # Copyright 2023 Salesforce, Inc. All rights reserved.
 [template]
+
+[placeholders.asset-version]
+type = "string"
+prompt = "Please provide an initial version for the policy to create"
+
 cargo_generate_version = ">=0.10.0"
 ignore = [
     "kilonova.yaml",


### PR DESCRIPTION
# Summary 

Now the template requires the initial version as a mandatory field. Also we are using the cargo PDK plugin to obtain the current version and pass it to the build-asset-files command.