### PR TITLE
[W-13735063] Use new pdk get-token command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEFINITION_NAME     = $(shell anypoint-cli-v4 pdk policy-project definition get 
 DEFINITION_GCL_PATH = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition)
 ASSET_VERSION       = $(shell cargo anypoint get-version)
 CRATE_NAME          = $(shell cargo anypoint get-name)
-OAUTH_TOKEN         = $(shell anypoint-cli-v4 conf token | grep -o '"token": *"[^"]*"' | cut -d '"' -f 4)
+OAUTH_TOKEN         = $(shell anypoint-cli-v4 pdk get-token)
 SETUP_ERROR_CMD		= (echo "ERROR:\n\tMissing custom policy project setup. Please run 'make setup'\n")
 
 ifeq ($(OS), Windows_NT)


### PR DESCRIPTION
# Summary

Use new get-token command instead of extracting it from `conf token` with post processing, since the token can be expired.