### PR TITLE
[W-13897350] Add asset-ids and group-id to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ definition_asset_id = "{{ project-name }}"
 asset_id = "{{ asset-id }}"
 
 [dependencies]
-pdk = { version = "{{ pdk-version | default: "1.0.0-beta.1" }}", registry = "anypoint" }
+pdk = { version = "{{ pdk_version | default: "1.0.0-beta.1" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ definition_asset_id = "{{ project-name }}"
 asset_id = "{{ asset-id }}"
 
 [dependencies]
-pdk = { version = "1.0.0-beta.1", registry = "anypoint" }
+pdk = { version = "{{ pdk-version | default: "1.0.0-beta.1" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.anypoint]
+group_id = "{{ group-id }}"
+definition_asset_id = "{{ project-name }}"
+asset_id = "{{ asset-id }}"
+
 [dependencies]
 pdk = { version = "1.0.0-beta.1", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CARGO_ANYPOINT        := cargo-anypoint
 DEFINITION_NAME        = $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
 DEFINITION_GCL_PATH    = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition)
 CRATE_NAME             = $(shell cargo anypoint get-name)
-ANYPOINT_METADATA_JSON = $(shell cargo anypoint get-anypoint-metadata-json)
+ANYPOINT_METADATA_JSON = $(shell cargo anypoint get-anypoint-metadata)
 OAUTH_TOKEN            = $(shell anypoint-cli-v4 pdk get-token)
 SETUP_ERROR_CMD        = (echo "ERROR:\n\tMissing custom policy project setup. Please run 'make setup'\n")
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ login:
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:
-	cargo +nightly install cargo-anypoint@{{ cargo-anypoint-version | default: "1.0.0-beta.1" }} --registry anypoint -Z registry-auth --config .cargo/config.toml
+	cargo +nightly install cargo-anypoint@{{ cargo_anypoint_version | default: "1.0.0-beta.1" }} --registry anypoint -Z registry-auth --config .cargo/config.toml
 
 ifneq ($(OS), Windows_NT)
 all: help

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-TARGET              := wasm32-wasi
-TARGET_DIR          := target/$(TARGET)/release
-CARGO_ANYPOINT      := cargo-anypoint
-DEFINITION_NAME     = $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
-DEFINITION_GCL_PATH = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition)
-ASSET_VERSION       = $(shell cargo anypoint get-version)
-CRATE_NAME          = $(shell cargo anypoint get-name)
-OAUTH_TOKEN         = $(shell anypoint-cli-v4 pdk get-token)
-SETUP_ERROR_CMD     = (echo "ERROR:\n\tMissing custom policy project setup. Please run 'make setup'\n")
+TARGET                := wasm32-wasi
+TARGET_DIR            := target/$(TARGET)/release
+CARGO_ANYPOINT        := cargo-anypoint
+DEFINITION_NAME        = $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
+DEFINITION_GCL_PATH    = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition)
+CRATE_NAME             = $(shell cargo anypoint get-name)
+ANYPOINT_METADATA_JSON = $(shell cargo anypoint get-anypoint-metadata-json)
+OAUTH_TOKEN            = $(shell anypoint-cli-v4 pdk get-token)
+SETUP_ERROR_CMD        = (echo "ERROR:\n\tMissing custom policy project setup. Please run 'make setup'\n")
 
 ifeq ($(OS), Windows_NT)
     SHELL = powershell.exe
@@ -42,7 +42,7 @@ release: build ## Publish a release version
 
 .phony: build-asset-files
 build-asset-files:
-	@anypoint-cli-v4 pdk policy-project build-asset-files --version $(ASSET_VERSION) --asset-id $(CRATE_NAME)
+	@anypoint-cli-v4 pdk policy-project build-asset-files --metadata '$(ANYPOINT_METADATA_JSON)'
 	@cargo anypoint config-gen -p -m $(DEFINITION_GCL_PATH) -o src/generated/config.rs
 
 .phony: login
@@ -51,7 +51,7 @@ login:
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:
-	cargo +nightly install cargo-anypoint@1.0.0-beta.1 --registry anypoint -Z registry-auth --config .cargo/config.toml
+	cargo +nightly install cargo-anypoint@1.0.0-dev.1 --registry anypoint -Z registry-auth --config .cargo/config.toml
 
 ifneq ($(OS), Windows_NT)
 all: help

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ login:
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:
-	cargo +nightly install cargo-anypoint@1.0.0-dev.1 --registry anypoint -Z registry-auth --config .cargo/config.toml
+	cargo +nightly install cargo-anypoint@{{ cargo-anypoint-version | default: "1.0.0-beta.1" }} --registry anypoint -Z registry-auth --config .cargo/config.toml
 
 ifneq ($(OS), Windows_NT)
 all: help

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -24,5 +24,17 @@ ignore = [
 type = "string"
 prompt = "Please provide an initial version for the policy to create"
 
+[placeholders.group-id]
+type = "string"
+prompt = "Please provide the group-id of the policy assets"
+
+[placeholders.asset-id]
+type = "string"
+prompt = "Please provide an asset-id for the policy"
+
+[placeholders.anypoint-registry-url]
+type = "string"
+prompt = "Please provide the URL of the Anypoint registry"
+
 [hooks]
 post = ["post-script.rhai"]


### PR DESCRIPTION
# Summary

In order to prevent using authentication in build-asset-files, we can now extract the group-id and the asset-ids from the Cargo.toml

This change requires pointing to a new cargo anypoint plugin, so pointing to version 1.0.0-dev.1