### PR TITLE
[W-14474259] Remove nightly usage and enforce Rust 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 [package]
 name = "{{ crate_name }}"
 version = "{{ asset-version }}"
+rust-version = "1.74.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ crate-type = ["cdylib"]
 [profile.release]
 lto = true
 opt-level = 'z'
+strip = "debuginfo"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 .phony: setup
 setup: login install-cargo-anypoint ## Setup all required tools to build
-	cargo +nightly fetch -Z registry-auth
+	cargo fetch
 
 .phony: build
 build: build-asset-files ## Build the policy definition and implementation
@@ -51,7 +51,7 @@ login:
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:
-	cargo +nightly install cargo-anypoint@{{ cargo_anypoint_version | default: "1.0.0-dev.1" }} --registry anypoint -Z registry-auth --config .cargo/config.toml
+	cargo install cargo-anypoint@{{ cargo_anypoint_version | default: "1.0.0-dev.1" }} --registry anypoint --config .cargo/config.toml
 
 ifneq ($(OS), Windows_NT)
 all: help


### PR DESCRIPTION
# Summary

- Synced changes with the main branch (two commits that were not present here in develop)
- Removed all nightly `-Z registry-auth` usages, since they are not necessary anymore with `1.74`
- Added min rust version `1.74` in `Cargo.yoml`