### PR TITLE
[W-13815584] Improving setup to prevent credentials prompt

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[registry]
+global-credential-providers = ["cargo:token"]
+
 [registries]
 anypoint = { index = "{{ anypoint-registry-url }}" }
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(OS), Windows_NT)
 endif
 
 .phony: setup
-setup: login install-cargo-anypoint ## Setup all required tools to build
+setup: registry-creds login install-cargo-anypoint ## Setup all required tools to build
 	cargo fetch
 
 .phony: build
@@ -48,6 +48,11 @@ build-asset-files:
 .phony: login
 login:
 	cargo login --registry anypoint $(OAUTH_TOKEN)
+
+.phony: registry-creds
+registry-creds:
+	@git config --global credential."https://qax.anypoint.mulesoft.com/git/68ef9520-24e9-4cf2-b2f5-620025690913/9be4ef3a-cb3e-479c-a1c4-e47cf2e02540".username me
+	@git config --global credential."https://qax.anypoint.mulesoft.com/git/68ef9520-24e9-4cf2-b2f5-620025690913/9be4ef3a-cb3e-479c-a1c4-e47cf2e02540".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ login:
 
 .phony: registry-creds
 registry-creds:
-	@git config --global credential."https://qax.anypoint.mulesoft.com/git/68ef9520-24e9-4cf2-b2f5-620025690913/9be4ef3a-cb3e-479c-a1c4-e47cf2e02540".username me
-	@git config --global credential."https://qax.anypoint.mulesoft.com/git/68ef9520-24e9-4cf2-b2f5-620025690913/9be4ef3a-cb3e-479c-a1c4-e47cf2e02540".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
+	git config --global credential."{{ anypoint-registry-url }}".username me
+	git config --global credential."{{ anypoint-registry-url }}".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ login:
 
 .phony: registry-creds
 registry-creds:
-	git config --global credential."{{ anypoint-registry-url }}".username me
-	git config --global credential."{{ anypoint-registry-url }}".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
+	@git config --global credential."{{ anypoint-registry-url }}".username me
+	@git config --global credential."{{ anypoint-registry-url }}".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:


### PR DESCRIPTION
# Summary

1. Added config override required by Cargo to authenticate with external registries. Using the default credential-provider `cargo:token` provided by cargo itself.
2. Updated `make setup` to include a git configuration that sets up a function to obtain the credentials for the Anypoint Git Registry for crates.