### PR TITLE
[W-14666631] Fix make run when crate name is changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build: build-asset-files ## Build the policy definition and implementation
 run: build ## Runs the policy in local flex
 	@anypoint-cli-v4 pdk log -t "warn" -m "Remember to update the config values in test/config/api.yaml file for the policy configuration"
 	@anypoint-cli-v4 pdk patch-gcl -f test/config/api.yaml -p "spec.policies[0].policyRef.name" -v "$(DEFINITION_NAME)-impl"
+	rm test/config/custom-policies/*.yaml
 	cp $(TARGET_DIR)/$(CRATE_NAME)_implementation.yaml test/config/custom-policies/$(CRATE_NAME)_implementation.yaml
 	cp $(TARGET_DIR)/$(CRATE_NAME)_definition.yaml test/config/custom-policies/$(CRATE_NAME)_definition.yaml
 	-docker compose -f ./test/docker-compose.yaml down


### PR DESCRIPTION
# Summary

When crate name was changed, we were leaving residual configuration yamls in `test/config/custom-policies` folder. That could lead to errors with missing properties, because flex will require configuration for older policy versions (versions with the prior crate name)

This PR fixes it by cleaning the folder before copying new configs and running again.