### PR TITLE
[W-14739147] Fix macOS, Windows and other platforms with cred helpers 401 on make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ login:
 .phony: registry-creds
 registry-creds:
 	@git config --global credential."{{ anypoint-registry-url }}".username me
-	@git config --global credential."{{ anypoint-registry-url }}".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
+	@# First removing other password helpers for Anypoint context
+	@git config --global --replace-all credential."{{ anypoint-registry-url }}".helper ""
+	@# Finally adding the only password helper for Anypoint context
+	@git config --global --add credential."{{ anypoint-registry-url }}".helper "!f() { test \"\$$1\" = get && echo \"password=\$$(anypoint-cli-v4 pdk get-token)\"; }; f"
 
 .phony: install-cargo-anypoint
 install-cargo-anypoint:


### PR DESCRIPTION
# Summary

## Issue 
- In `make setup` command we authenticate with the platform registry that provides the PDK crates.
- To authenticate against our private registries we obtain a token with Anypoint CLI and use it as credential using a custom git credential helper.
- The buggy behavior was that, in MacOs systems, same as other systems with built-in keychain cred helpers for Git, the platform underlying cred helper was caching the credentials indefinitely. But that's not correct because our credentials are ephemeral. Hence, every now and then, we would get an unexpected 401 Unauthorized error.

## Fix

The explanation of other cred helpers being executed along with our custom helper is in [git documentation](https://git-scm.com/docs/gitcredentials#:~:text=If%20there%20are%20multiple%20instances%20of%20the%20credential.helper%20configuration%20variable%2C%20each%20helper%20will%20be%20tried%20in%20turn%2C%20and%20may%20provide%20a%20username%2C%20password%2C%20or%20nothing.).

The same documentation also [explains how to void the rest of the helpers and replacing them with a single one](https://git-scm.com/docs/gitcredentials#:~:text=If%20credential.helper%20is%20configured%20to%20the%20empty%20string%2C%20this%20resets%20the%20helper%20list%20to%20empty%20(so%20you%20may%20override%20a%20helper%20set%20by%20a%20lower%2Dpriority%20config%20file%20by%20configuring%20the%20empty%2Dstring%20helper%2C%20followed%20by%20whatever%20set%20of%20helpers%20you%20would%20like).).

This PR applies that fix, and uses the flag `--replace-all` to be idempotent, this means, run `make setup` as many times you want without being broken for trying to set the same configuration multiple times.