### PR TITLE
[W-14740227] Updating PDK imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ mod generated;
 
 use anyhow::{anyhow, Result};
 
-use pdk::api::hl::*;
+use pdk::hl::*;
+use pdk::logger;
 
 use crate::generated::config::Config;
 

--- a/tests/requests/hello/api.yaml
+++ b/tests/requests/hello/api.yaml
@@ -17,8 +17,10 @@ spec:
 
         # Override the `{{project-name}}` placeholder with the actual policy name.
         # Look for the actual policy name at the `metadata.name` property from the `gcl.yaml` file.
-        name: {{project-name}}       
-        
+        name: {{project-name}}
+        # Also, if the policy definition gcl.yaml specifies a namespace other than default, override it too
+        namespace: default
+
       # Fill the config with a policy configuration that matches the schema specified in the policy
       # definition gcl.yaml. Eg:
       # config:


### PR DESCRIPTION
# Summary

- Updating PDK imports to reflect new modularization in PDK
- Extra: Adding namespace in testing fwk default configuration, and recommending to override it if the definition gcl contains a different namespace.