### PR TITLE
[W-14830569] Add flag to show logs in integration test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ run: build ## Run the policy in local flex
 
 .PHONY: test
 test: build ## Run integration tests
-	@cargo test
+	@cargo test -- --nocapture
 
 .PHONY: publish
 publish: build ## Publish a development version of the policy


### PR DESCRIPTION
# Summary

Adding flag --nocapture to include print logs in test functions. See [cargo test documentation](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options) for reference about nocapture flag.