### PR TITLE
W-18393295: Update target from wasm32-wasi to wasm32-wasip1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "{{ crate_name }}"
 version = "{{ asset-version }}"
-rust-version = "1.83.0"
+rust-version = "1.86.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "{{ crate_name }}"
 version = "{{ asset-version }}"
-rust-version = "1.86.0"
+rust-version = "1.83.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET                	:= wasm32-wasi
+TARGET                	:= wasm32-wasip1
 TARGET_DIR            	:= target/$(TARGET)/release
 CARGO_ANYPOINT        	:= cargo-anypoint
 POLICY_REF_NAME_SUFFIX 	:= -flex

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,7 @@
 // This module contains common Rust stuff shared between test files.
 
 // Directory where the policies implementations are stored.
-pub const POLICY_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/target/wasm32-wasi/release");
+pub const POLICY_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/target/wasm32-wasip1/release");
 
 // Directory with the common configurations for tests.
 pub const COMMON_CONFIG_DIR: &str =  concat!(env!("CARGO_MANIFEST_DIR"), "/tests/config");


### PR DESCRIPTION
Update compilation target from `wasm32-wasi` to `wasm32-wasip1`.