### PR TITLE
W-18697356: Update Flex version to 1.10.0

### DIFF
--- a/playground/docker-compose.yaml
+++ b/playground/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   local-flex:
-    image: mulesoft/flex-gateway:1.7.0
+    image: mulesoft/flex-gateway:1.10.0
     ports:
       - 8081:8081
     volumes:

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -40,7 +40,7 @@ async fn hello() -> anyhow::Result<()> {
 
     // Configure a Flex service
     let flex_config = FlexConfig::builder()
-        .version("1.7.0")
+        .version("1.10.0")
         .hostname("local-flex")
         .with_api(api_config)
         .config_mounts([


### PR DESCRIPTION
Updating Flex version from `1.7.0` to `1.10.0`.

Tested running E2E successfully with following params:

- OS: `Linux`
- NPM_REGISTRY: `INTERNAL_NPM`
- ANYPOINT_CLI_PLUGIN_VERSION: `latest`
- FEATURE_BRANCH: `feature/W-18697356`
- ENVIRONMENT: `qax`

E2E successful run: https://dragon-ci.kbuild.msap.io/onprem-bravo/job/API-Gateway/job/microgateway-pdk-cli-e2e-tests/job/feature%252FW-18697356/2/