### PR TITLE
@W-19720182: Allow Git paths for pdk and pdk-test dependencies [Agnostic PDK]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source }}
+pdk = "{{ pdk_source }}"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source }}
+pdk-test = "{{ pdk_source }}"
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source }}
+pdk-test = {{ pdk_test_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk = {{ pdk_source | \"{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }\" }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk-test = {{ pdk_source | \"{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }\" }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk = {{ pdk_source }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk-test = {{ pdk_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_test_source }}
+pdk-test = {{ pdk_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk = {{ pdk_source }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk-test = {{ pdk_test_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = "{{ pdk_source }}"
+pdk = {{ pdk_source }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = "{{ pdk_source }}"
+pdk-test = {{ pdk_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
+pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }" }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
+pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }" }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }" }}
+pdk = {{ pdk_source }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }" }}
+pdk-test = {{ pdk_source }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source | \"{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }\" }}
+pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source | \"{ version = \"{{ pdk_version }}\", registry = \"anypoint\" }\" }}
+pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk", version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk", version = "{{ pdk_version | default: \"1.6.0-rc.0\" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk-test", version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
+pdk-test = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk-test", version = "{{ pdk_version | default: \"1.6.0-rc.0\" }}", registry = "anypoint" }
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source }}
+pdk = { version = "1.4.0", registry = "anypoint"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source }}
+pdk-test = { version = "1.4.0", registry = "anypoint"}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
+pdk = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk", version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
+pdk-test = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk-test", version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk", version = "{{ pdk_version | default: \"1.6.0-rc.0\" }}", registry = "anypoint" }
+pdk = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk-test", version = "{{ pdk_version | default: \"1.6.0-rc.0\" }}", registry = "anypoint" }
+pdk-test = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = { version = "1.4.0", registry = "anypoint"}
+pdk = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = { version = "1.4.0", registry = "anypoint"}
+pdk-test = { version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ definition_asset_id = "{{ project-name }}"
 implementation_asset_id = "{{ implementation-asset-id }}"
 
 [dependencies]
-pdk = {{ pdk_source }}
+pdk = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 anyhow = "1.0"
 
 [dev-dependencies]
-pdk-test = {{ pdk_source }}
+pdk-test = {{ pdk_source | default: "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }" }}
 httpmock = "0.6"
 reqwest = "0.11"
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,10 +38,5 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
-[placeholders.pdk_source]
-type = "string"
-prompt = "PDK dependency configuration (leave empty for default)"
-default = "{ version = \"{{ default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
-
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -39,4 +39,5 @@ type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
 [hooks]
+pre = ["pre-script.rhai"]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -43,10 +43,5 @@ type = "string"
 prompt = "PDK source configuration"
 default = "{ version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }"
 
-[placeholders.pdk_test_source]
-type = "string"
-prompt = "PDK-test source configuration
-default = "{ version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }"
-
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,14 +38,5 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
-[placeholders.pdk_version]
-type = "string"
-prompt = "PDK version (leave empty for default)"
-default = "1.6.0-rc.0"
-
-[placeholders.pdk_source]
-type = "string"
-prompt = "PDK dependency configuration (leave empty for default)"
-
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,5 +38,15 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
+[placeholders.pdk_version]
+type = "string"
+prompt = "PDK version (leave empty for default)"
+default = "1.6.0-rc.0"
+
+[placeholders.pdk_source]
+type = "string"
+prompt = "PDK source configuration (leave empty for default)"
+default = ""
+
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -41,7 +41,7 @@ prompt = "Please provide the URL of the Anypoint registry"
 [placeholders.pdk_source]
 type = "string"
 prompt = "PDK dependency configuration (leave empty for default)"
-default = "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
+default = "{ version = \"{{ default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
 
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,5 +38,14 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
+[placeholders.pdk_version]
+type = "string"
+prompt = "PDK version (leave empty for default)"
+default = "1.6.0-rc.0"
+
+[placeholders.pdk_source]
+type = "string"
+prompt = "PDK dependency configuration (leave empty for default)"
+
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -41,7 +41,7 @@ prompt = "Please provide the URL of the Anypoint registry"
 [placeholders.pdk_source]
 type = "string"
 prompt = "PDK source configuration"
-default = "{ version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }"
+default = "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
 
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,10 +38,5 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
-[placeholders.pdk_source]
-type = "string"
-prompt = "PDK source configuration"
-default = "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
-
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,5 +38,15 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
+[placeholders.pdk_source]
+type = "string"
+prompt = "PDK source configuration"
+default = "{ version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }"
+
+[placeholders.pdk_test_source]
+type = "string"
+prompt = "PDK-test source configuration
+default = "{ version = "{{ pdk_version | default: "1.6.0-rc.0" }}", registry = "anypoint" }"
+
 [hooks]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -38,15 +38,10 @@ prompt = "Please provide an implementation-asset-id for the policy"
 type = "string"
 prompt = "Please provide the URL of the Anypoint registry"
 
-[placeholders.pdk_version]
-type = "string"
-prompt = "PDK version (leave empty for default)"
-default = "1.6.0-rc.0"
-
 [placeholders.pdk_source]
 type = "string"
-prompt = "PDK source configuration (leave empty for default)"
-default = ""
+prompt = "PDK dependency configuration (leave empty for default)"
+default = "{ version = \"{{ pdk_version | default: \"1.6.0-rc.0\" }}\", registry = \"anypoint\" }"
 
 [hooks]
 post = ["post-script.rhai"]

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -1,0 +1,13 @@
+// Copyright 2023 Salesforce, Inc. All rights reserved.
+
+const PDK_SOURCE = "pdk_source";
+const PDK_VERSION = "pdk_version";
+
+if variable::is_set(PDK_SOURCE) {
+    // If pdk_source is set, use it directly
+} else if variable::is_set(PDK_VERSION) {
+    let version = variable::get(PDK_VERSION);
+    variable::set(PDK_SOURCE, `{ version = "${version}", registry = "anypoint" }`)
+} else {
+    variable::set(PDK_SOURCE, `{ version = "1.6.0-rc.0", registry = "anypoint" }`)
+}

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -1,13 +1,19 @@
 // Copyright 2023 Salesforce, Inc. All rights reserved.
 
 const PDK_SOURCE = "pdk_source";
+const PDK_TEST_SOURCE = "pdk_test_source";
 const PDK_VERSION = "pdk_version";
 
+// pdk dependency
 if variable::is_set(PDK_SOURCE) {
-    // If pdk_source is set, use it directly
 } else if variable::is_set(PDK_VERSION) {
     let version = variable::get(PDK_VERSION);
     variable::set(PDK_SOURCE, `{ version = "${version}", registry = "anypoint" }`)
 } else {
     variable::set(PDK_SOURCE, `{ version = "1.6.0-rc.0", registry = "anypoint" }`)
+}
+
+// pdk-test dependency
+if !variable::is_set(PDK_TEST_SOURCE) {
+    variable::set(PDK_TEST_SOURCE, variable::get(PDK_SOURCE))
 }

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -4,12 +4,13 @@ const PDK_SOURCE = "pdk_source";
 const PDK_TEST_SOURCE = "pdk_test_source";
 const PDK_VERSION = "pdk_version";
 
-if variable::is_set(PDK_SOURCE) {
-} else if variable::is_set(PDK_VERSION) {
-    let version = variable::get(PDK_VERSION);
-    variable::set(PDK_SOURCE, `{ version = "${version}", registry = "anypoint" }`)
-} else {
-    variable::set(PDK_SOURCE, `{ version = "1.6.0-rc.0", registry = "anypoint" }`)
+if !variable::is_set(PDK_SOURCE) {
+    if variable::is_set(PDK_VERSION) {
+        let version = variable::get(PDK_VERSION);
+        variable::set(PDK_SOURCE, `{ version = "${version}", registry = "anypoint" }`)
+    } else {
+        variable::set(PDK_SOURCE, `{ version = "1.6.0-rc.0", registry = "anypoint" }`)
+    }
 }
 
 if !variable::is_set(PDK_TEST_SOURCE) {

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -4,7 +4,6 @@ const PDK_SOURCE = "pdk_source";
 const PDK_TEST_SOURCE = "pdk_test_source";
 const PDK_VERSION = "pdk_version";
 
-// pdk dependency
 if variable::is_set(PDK_SOURCE) {
 } else if variable::is_set(PDK_VERSION) {
     let version = variable::get(PDK_VERSION);
@@ -13,7 +12,6 @@ if variable::is_set(PDK_SOURCE) {
     variable::set(PDK_SOURCE, `{ version = "1.6.0-rc.0", registry = "anypoint" }`)
 }
 
-// pdk-test dependency
 if !variable::is_set(PDK_TEST_SOURCE) {
     variable::set(PDK_TEST_SOURCE, variable::get(PDK_SOURCE))
 }


### PR DESCRIPTION
### Changes 
Add variables to allow `pdk` and `pdk-test` dependencies to be retrieved from Git too, as until now they could only be retrieved from the default registry.

### How will it work?

`pdk`: 
1. First, this will try to retrieve the pdk dep from `pdk_source`. If we intend to use it for retrieving from Git it should be something like:
`"{git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk"}"`

2. If `pdk_source` was not set, it will try with `pdk_version` (which should be something like `"1.6.0-rc.1"`)

3. If `pdk_version` is also unset, it will use the default (currently `"1.6.0-rc.0"`).

`pdk-test`: Will always use same source as `pdk` unless explicitely defining `pdk_test_source`.

### Tests

I tested this using:

```
cargo generate --init --path ../microgateway-custom-policy-template
-n test-separate-pdk-test
-d group-id=test
-d implementation-asset-id=test
-d asset-version=1.0.0
-d anypoint-registry-url=https://test.com
-d pdk_source='{ git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk" }'
-d pdk_test_source='{ git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "test-branch", package = "pdk-test" }'
```

And at the `Cargo.toml` I got:

```
pdk = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "master", package = "pdk" }
pdk-test = { git = "https://github.com/mulesoft-emu/mgw-policy-development-kit.git", branch = "test-branch", package = "pdk-test" }
```