### PR TITLE
@W-21681442 Add FIPS compliance support to project template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export PDK_COMPATIBILITY_VERSION = 1.4.0
 TARGET                	:= wasm32-wasip1
 TARGET_DIR            	:= target/$(TARGET)/release
 CARGO_ANYPOINT        	:= cargo-anypoint
-FIPS                   	:= {% if fips %}true{% else %}false{% endif %}
+FLAGS                  	= {% if fips %}RUSTFLAGS="--cfg fips"{% endif %}
 DEFINITION_NAME        	= $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
 DEFINITION_NAMESPACE   	= $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-namespace)
 DEFINITION_SRC_GCL_PATH = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition-src)
@@ -30,11 +30,7 @@ setup: install-cargo-anypoint install-llvm-cov ## Setup Cargo Anypoint to build,
 
 .PHONY: build
 build: build-asset-files ## Build the policy definition and implementation
-ifeq ($(FIPS),true)
-	@RUSTFLAGS="--cfg fips" cargo build --target $(TARGET) --release
-else
-	@cargo build --target $(TARGET) --release
-endif
+	@$(FLAGS) cargo build --target $(TARGET) --release
 	@cp "$(DEFINITION_GCL_PATH)" "$(TARGET_DIR)/$(CRATE_NAME)_definition.yaml"
 	@cargo anypoint gcl-gen -d $(DEFINITION_NAME) -n $(DEFINITION_NAMESPACE) -w $(TARGET_DIR)/$(CRATE_NAME).wasm -o $(TARGET_DIR)/$(CRATE_NAME)_implementation.yaml
 	@echo $(POLICY_REF_NAME) > target/policy-ref-name.txt

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export PDK_COMPATIBILITY_VERSION = 1.4.0
 TARGET                	:= wasm32-wasip1
 TARGET_DIR            	:= target/$(TARGET)/release
 CARGO_ANYPOINT        	:= cargo-anypoint
+FIPS                   	:= {% if fips %}true{% else %}false{% endif %}
 DEFINITION_NAME        	= $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-name)
 DEFINITION_NAMESPACE   	= $(shell anypoint-cli-v4 pdk policy-project definition get gcl-metadata-namespace)
 DEFINITION_SRC_GCL_PATH = $(shell anypoint-cli-v4 pdk policy-project locate-gcl definition-src)
@@ -29,7 +30,11 @@ setup: install-cargo-anypoint install-llvm-cov ## Setup Cargo Anypoint to build,
 
 .PHONY: build
 build: build-asset-files ## Build the policy definition and implementation
+ifeq ($(FIPS),true)
+	@RUSTFLAGS="--cfg fips" cargo build --target $(TARGET) --release
+else
 	@cargo build --target $(TARGET) --release
+endif
 	@cp "$(DEFINITION_GCL_PATH)" "$(TARGET_DIR)/$(CRATE_NAME)_definition.yaml"
 	@cargo anypoint gcl-gen -d $(DEFINITION_NAME) -n $(DEFINITION_NAMESPACE) -w $(TARGET_DIR)/$(CRATE_NAME).wasm -o $(TARGET_DIR)/$(CRATE_NAME)_implementation.yaml
 	@echo $(POLICY_REF_NAME) > target/policy-ref-name.txt

--- a/Makefile-implementation
+++ b/Makefile-implementation
@@ -3,7 +3,7 @@ TARGET                	:= wasm32-wasip1
 TARGET_DIR            	:= target/$(TARGET)/release
 BUILD_POLICY_DIR        := target
 CARGO_ANYPOINT        	:= cargo-anypoint
-FIPS                   	:= {% if fips %}true{% else %}false{% endif %}
+FLAGS                  	= {% if fips %}RUSTFLAGS="--cfg fips"{% endif %}
 CRATE_NAME		        = $(shell cargo anypoint get-name)
 DEFINITION_GAV          = $(shell cargo anypoint get-policy-definition-gav)
 DEFINITION_NAMESPACE    := default
@@ -28,11 +28,7 @@ build-asset-files:  ## Retrieves the definition from exchange
 
 .PHONY: build
 build: ## Builds the policy implementation
-ifeq ($(FIPS),true)
-	@RUSTFLAGS="--cfg fips" cargo build --target $(TARGET) --release
-else
-	@cargo build --target $(TARGET) --release
-endif
+	@$(FLAGS) cargo build --target $(TARGET) --release
 	@cargo anypoint build-policy --target=$(BUILD_POLICY_DIR) --wasm=$(TARGET_DIR)/$(CRATE_NAME).wasm --min-runtime-version=$(MIN_FLEX_VERSION)
 	@anypoint-cli-v4 pdk install-policy --target $(TARGET_DIR) --path $(BUILD_POLICY_DIR)/$(CRATE_NAME)/implementation/
 	@echo $(POLICY_REF_NAME) > target/policy-ref-name.txt

--- a/Makefile-implementation
+++ b/Makefile-implementation
@@ -3,6 +3,7 @@ TARGET                	:= wasm32-wasip1
 TARGET_DIR            	:= target/$(TARGET)/release
 BUILD_POLICY_DIR        := target
 CARGO_ANYPOINT        	:= cargo-anypoint
+FIPS                   	:= {% if fips %}true{% else %}false{% endif %}
 CRATE_NAME		        = $(shell cargo anypoint get-name)
 DEFINITION_GAV          = $(shell cargo anypoint get-policy-definition-gav)
 DEFINITION_NAMESPACE    := default
@@ -27,7 +28,11 @@ build-asset-files:  ## Retrieves the definition from exchange
 
 .PHONY: build
 build: ## Builds the policy implementation
+ifeq ($(FIPS),true)
+	@RUSTFLAGS="--cfg fips" cargo build --target $(TARGET) --release
+else
 	@cargo build --target $(TARGET) --release
+endif
 	@cargo anypoint build-policy --target=$(BUILD_POLICY_DIR) --wasm=$(TARGET_DIR)/$(CRATE_NAME).wasm --min-runtime-version=$(MIN_FLEX_VERSION)
 	@anypoint-cli-v4 pdk install-policy --target $(TARGET_DIR) --path $(BUILD_POLICY_DIR)/$(CRATE_NAME)/implementation/
 	@echo $(POLICY_REF_NAME) > target/policy-ref-name.txt

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This project is designed to scaffold custom policy implementation projects using
 
 In short, this is the archetype of Flex Gateway custom policy implementations.
 
+## FIPS Compliance
+
+Projects can be created with FIPS compliance enabled using the `--fips` flag. This configures the PDK to use FIPS-compliant cryptographic modules. Note that this affects PDK cryptographic operations; custom policy code must also avoid non-compliant dependencies to maintain full compliance.
+

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -34,11 +34,6 @@ prompt = "Please provide the group-id of the policy assets"
 type = "string"
 prompt = "Please provide an implementation-asset-id for the policy"
 
-[placeholders.fips]
-type = "bool"
-prompt = "Enable FIPS compliance?"
-default = false
-
 [hooks]
 pre = ["pre-script.rhai"]
 post = ["post-script.rhai"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -34,6 +34,11 @@ prompt = "Please provide the group-id of the policy assets"
 type = "string"
 prompt = "Please provide an implementation-asset-id for the policy"
 
+[placeholders.fips]
+type = "bool"
+prompt = "Enable FIPS compliance?"
+default = false
+
 [hooks]
 pre = ["pre-script.rhai"]
 post = ["post-script.rhai"]

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -7,6 +7,8 @@ const PDK_VERSION = "pdk_version";
 const PROJECT_MODE = "project-mode";
 const DEFAULT_PROJECT_MODE = "unified";
 
+const FIPS = "fips";
+
 if !variable::is_set(PDK_SOURCE) {
     if variable::is_set(PDK_VERSION) {
         let version = variable::get(PDK_VERSION);
@@ -22,4 +24,8 @@ if !variable::is_set(PDK_TEST_SOURCE) {
 
 if !variable::is_set(PROJECT_MODE) {
     variable::set(PROJECT_MODE, DEFAULT_PROJECT_MODE)
+}
+
+if !variable::is_set(FIPS) {
+    variable::set(FIPS, false)
 }


### PR DESCRIPTION
Add `fips` placeholder to generate projects with FIPS 140-3 compliant builds.

When enabled, generated Makefile includes `RUSTFLAGS="--cfg fips"` to compile PDK with FIPS compliant.

Changes:
- cargo-generate.toml: fips placeholder
- pre-script.rhai: default fips=false
- Makefile: conditional RUSTFLAGS
- README: FIPS disclaimer