### PR TITLE
@W-21200338 [Makefile] Add TEST parameter to run a single test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 	-docker compose -f ./playground/docker-compose.yaml down
 	docker compose -f ./playground/docker-compose.yaml up
 
-# Set TEST with a specific test name to run a single test using make test. Example: TEST=hello
+# Set TEST with a specific test name to run a single test using make test. Example: TEST=mytest
 TEST ?=
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ endif
 	-docker compose -f ./playground/docker-compose.yaml down
 	docker compose -f ./playground/docker-compose.yaml up
 
-# Set TEST with a specific test name to run a single test using make test. Example: TEST=mytest
+# Set TEST with a specific test name to run a single test using make test. Example: TEST=my_test
 TEST ?=
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ endif
 	-docker compose -f ./playground/docker-compose.yaml down
 	docker compose -f ./playground/docker-compose.yaml up
 
+# Set TEST with a specific test name to run a single test using make test. Example: TEST=hello
 TEST ?=
 
-# Set TEST with a specific test name to run a single test. Example: TEST=hello
 .PHONY: test
 test: build tests/config/registration.yaml ## Run integration tests
 	@cargo test $(TEST) -- --nocapture

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,9 @@ endif
 
 TEST ?=
 
+# Set TEST with a specific test name to run a single test. Example: TEST=hello
 .PHONY: test
-test: build tests/config/registration.yaml ## Run integration tests (use TEST=name to run a single test)
+test: build tests/config/registration.yaml ## Run integration tests
 	@cargo test $(TEST) -- --nocapture
 
 FORMAT     ?=

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,11 @@ endif
 	-docker compose -f ./playground/docker-compose.yaml down
 	docker compose -f ./playground/docker-compose.yaml up
 
+TEST ?=
+
 .PHONY: test
-test: build tests/config/registration.yaml ## Run integration tests
-	@cargo test -- --nocapture
+test: build tests/config/registration.yaml ## Run integration tests (use TEST=name to run a single test)
+	@cargo test $(TEST) -- --nocapture
 
 FORMAT     ?=
 OUTPUT_PATH ?=

--- a/Makefile-implementation
+++ b/Makefile-implementation
@@ -45,9 +45,12 @@ run: build playground/registration.yaml  ## Run the policy in local flex
 	-docker compose -f ./playground/docker-compose.yaml down
 	docker compose -f ./playground/docker-compose.yaml up
 
+# Set TEST with a specific test name to run a single test using make test. Example: TEST=my_test
+TEST ?=
+
 .PHONY: test
 test: build tests/config/registration.yaml ## Run integration tests
-	@cargo test -- --nocapture
+	@cargo test $(TEST) -- --nocapture
 
 FORMAT     ?=
 OUTPUT_PATH ?=


### PR DESCRIPTION
Adds an optional `TEST` variable to the `make test` target so developers can run a single test with `make test TEST=name`. When `TEST` is empty, the full suite still runs, so existing behavior is unchanged.

The parameter is documented in the target's help comment, so it appears in `make help`.

Resolves W-21200338.